### PR TITLE
Programming contests page mobile view padding fixed

### DIFF
--- a/css/contests.css
+++ b/css/contests.css
@@ -210,7 +210,7 @@ li:hover {
 
     .title {
         font-size: 30px;
-        padding: 30px 0 30px 0;
+        padding: 20px 0 20px 0;
         text-align: center;
     }
 
@@ -220,6 +220,13 @@ li:hover {
         height: auto;
     }
 
+    .contestsSpace {
+        padding: 40px 30px 40px 30px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center
+    }
     .nav{
         flex-direction: column-reverse;
         width: 100%;


### PR DESCRIPTION
* Changes made to media query of card of a contest,
Removed excess padding and centered contents inside the card.
* Also reduced padding in main title

Earlier:

![mcontests](https://user-images.githubusercontent.com/23053768/34783333-4fd60c88-f651-11e7-8562-4b5c77cfbee0.PNG)
 
Now:

![nmcontests](https://user-images.githubusercontent.com/23053768/34783357-632082a0-f651-11e7-9804-7ea3e38bb52b.PNG)
